### PR TITLE
Implements [ticket] signboard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,14 +125,14 @@
     <dependency>
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
-      <version>1.14.2-R0.1-SNAPSHOT</version>
+      <version>1.15.2-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <!--Bukkit API-->
     <dependency>
       <groupId>org.bukkit</groupId>
       <artifactId>bukkit</artifactId>
-      <version>1.14.2-R0.1-SNAPSHOT</version>
+      <version>1.15.2-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-io -->

--- a/src/main/java/space/gorogoro/gacha/Gacha.java
+++ b/src/main/java/space/gorogoro/gacha/Gacha.java
@@ -10,6 +10,7 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.entity.Player;
 
 import net.milkbowl.vault.economy.Economy;
 
@@ -153,7 +154,7 @@ public class Gacha extends JavaPlugin{
 
         case "ticket":
           if(sender.hasPermission("gacha.ticket")) {
-            command.ticket(econ);
+            command.ticket(econ, (Player)sender);
             hideUseageFlag = true;
           }
           break;

--- a/src/main/java/space/gorogoro/gacha/GachaCommand.java
+++ b/src/main/java/space/gorogoro/gacha/GachaCommand.java
@@ -12,6 +12,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
+
 /*
  * FrameGuardCommand
  * @license    LGPLv3
@@ -124,88 +125,78 @@ public class GachaCommand {
   }
 
   /**
-   * Processing of command ticket.
+   * Processing of ticket.
    * @return boolean true:Success false:Failure
    */
 	public boolean ticket(Economy econ) {
+        Player player = (Player) sender;
+        int playerSlot = player.getInventory().firstEmpty();
+        if (playerSlot == -1) { // 空のスロットがない
+            sender.sendMessage("エラー：インベントリを空けてください！");
+            return false;
+        }
 
-		if (args.length != 2) {
-			return false;
-		}
-		Player player;
-		if (sender instanceof Player) {
-			player = (Player) sender;
-		} else {
-			// player でない場合は処理をしない
-			return false;
-		}
-		String playerName = args[1];
-		int playerSlot = player.getInventory().firstEmpty();
-		/* プレーヤ名が@pだったら */
-		if ("@p".equals(playerName)) {
-			playerName = sender.getName();
+        if (!(payTicketPrice(econ, player))) {
+            return false;
+        }
 
-			if (playerSlot == -1) { // 空のスロットがない
-				sender.sendMessage(String.format("エラー：イベントリを空けてください！"));
-				return false;
-			}
+        return issueTicket(player, playerSlot);
+    }
 
-			/* 現在のお金を表示 */
-			sender.sendMessage(String.format("現在の現金 %s", econ.format(econ.getBalance(player))));
+    /**
+     * チケット代を支払う
+     * @param econ
+     * @param player
+     * @return boolean true: Success, false: Failure
+     */
+    private boolean payTicketPrice(Economy econ, Player player) {
+        sender.sendMessage(String.format("現在の現金 %s", econ.format(econ.getBalance(player))));
 
-			if (econ.has(player, TICKET_PRICE)) {
-				EconomyResponse r = econ.withdrawPlayer(player, TICKET_PRICE);
-				if (r.transactionSuccess()) {
-					sender.sendMessage(String.format("お買い上げありがとうございます！$%s頂きました！", TICKET_PRICE));
-				} else {
-					sender.sendMessage(String.format("An error occured: %s", r.errorMessage));
-					return false;
-				}
-			} else {
-				sender.sendMessage(String.format("$%s持っていません！", TICKET_PRICE));
-				return false;
+        if (!(econ.has(player, TICKET_PRICE))) {
+            sender.sendMessage(String.format("$%s持っていません！", TICKET_PRICE));
+            return false;
+        }
 
-			}
-		/* コンソールからだったらまたはOPからだったら */
-		// 何も処理をしていない上にバグの元になるので一旦コメントアウト
-		/*
-		} else if ((sender instanceof ConsoleCommandSender) || sender.isOp()) {
-			player = gacha.getServer().getPlayer(playerName);
-			if (player == null) {
-				return false;
-			}
-		*/
-		} else {
-			return false;
-		}
-		/*
-		 * 名前でチケットの受取は使わない Player player = gacha.getServer().getPlayer(playerName);
-		 * if(player == null) { return false; }
-		 */
-		/* チケットの発券機能 */
+        EconomyResponse r = econ.withdrawPlayer(player, TICKET_PRICE);
 
-		String ticketCode = gacha.getDatabase().getTicket();
-		if (ticketCode == null) {
-			GachaUtility.sendMessage(sender, "Failure generate ticket code.");
-			return false;
-		}
+        if (!(r.transactionSuccess())) {
+            sender.sendMessage(String.format("An error occurred: %s", r.errorMessage));
+            return false;
+        }
 
-		ItemStack ticket = new ItemStack(Material.PAPER, 1);
-		ItemMeta im = ticket.getItemMeta();
-		im.setDisplayName(
-				ChatColor.translateAlternateColorCodes('&', gacha.getConfig().getString("ticket-display-name")));
-		ArrayList<String> lore = new ArrayList<String>();
-		lore.add(ChatColor.translateAlternateColorCodes('&', gacha.getConfig().getString("ticket-lore1")));
-		lore.add(ChatColor.translateAlternateColorCodes('&', gacha.getConfig().getString("ticket-lore2")));
-		lore.add(String.format(FORMAT_TICKET_CODE, ticketCode));
-		im.setLore(lore);
-		ticket.setItemMeta(im);
-		player.getInventory().setItem(playerSlot, ticket);
-		GachaUtility.sendMessage(sender, "Issue a ticket. player_name=" + playerName);
-		return true;
-	}
+        sender.sendMessage(String.format("お買い上げありがとうございます！$%s頂きました！", TICKET_PRICE));
+        return true;
+    }
 
-  /**
+    /**
+     * チケットを発券する
+     * @param player
+     * @param playerSlot
+     * @return boolean
+     */
+    private boolean issueTicket(Player player, int playerSlot) {
+        String ticketCode = gacha.getDatabase().getTicket();
+        if (ticketCode == null) {
+            GachaUtility.sendMessage(sender, "Failure generate ticket code.");
+            return false;
+        }
+
+        ItemStack ticket = new ItemStack(Material.PAPER, 1);
+        ItemMeta im = ticket.getItemMeta();
+        im.setDisplayName(
+                ChatColor.translateAlternateColorCodes('&', gacha.getConfig().getString("ticket-display-name")));
+        ArrayList<String> lore = new ArrayList<String>();
+        lore.add(ChatColor.translateAlternateColorCodes('&', gacha.getConfig().getString("ticket-lore1")));
+        lore.add(ChatColor.translateAlternateColorCodes('&', gacha.getConfig().getString("ticket-lore2")));
+        lore.add(String.format(FORMAT_TICKET_CODE, ticketCode));
+        im.setLore(lore);
+        ticket.setItemMeta(im);
+        player.getInventory().setItem(playerSlot, ticket);
+        GachaUtility.sendMessage(sender, "Issue a ticket. player_name=" + sender.getName());
+        return true;
+    }
+
+    /**
    * Processing of command reload.
    * @return boolean true:Success false:Failure
    */

--- a/src/main/java/space/gorogoro/gacha/GachaCommand.java
+++ b/src/main/java/space/gorogoro/gacha/GachaCommand.java
@@ -31,7 +31,7 @@ public class GachaCommand {
 
   /**
    * Constructor of GachaCommand.
-   * @param Gacha gacha
+   * @param gacha Gacha instance
    */
 	public GachaCommand(Gacha gacha) {
 		try {
@@ -43,8 +43,8 @@ public class GachaCommand {
 
   /**
    * Initialize
-   * @param CommandSender CommandSender
-   * @param String[] Argument
+   * @param sender CommandSender instance
+   * @param args /gacha 以降のマインクラフト内コマンド引数
    */
   public void initialize(CommandSender sender, String[] args){
     try{
@@ -102,7 +102,7 @@ public class GachaCommand {
       GachaUtility.sendMessage(sender, "Record not found. gacha_name=" + gachaName);
       return true;
     }
-    GachaUtility.setPunch((Player)sender, gacha, gachaName);
+    GachaUtility.setPunch((Player) sender, gacha, gachaName);
     GachaUtility.sendMessage(sender, "Please punching(right click) a chest of gachagacha. gacha_name=" + gachaName);
     return true;
   }
@@ -118,7 +118,7 @@ public class GachaCommand {
 
     String gachaName = args[1];
     if(gacha.getDatabase().deleteGacha(gachaName)) {
-      GachaUtility.sendMessage(sender, "Deleted. gacha_name=" + gachaName);
+      GachaUtility.sendMessage(sender, "Deleted. gacha_name = " + gachaName);
       return true;
     }
     return false;
@@ -126,13 +126,13 @@ public class GachaCommand {
 
   /**
    * Processing of ticket.
+   * @param econ Economy instance
+   * @param player Player instance
    * @return boolean true:Success false:Failure
    */
-	public boolean ticket(Economy econ) {
-        Player player = (Player) sender;
-        int playerSlot = player.getInventory().firstEmpty();
-        if (playerSlot == -1) { // 空のスロットがない
-            sender.sendMessage("エラー：インベントリを空けてください！");
+	public boolean ticket(Economy econ, Player player) {
+        if (player.getInventory().firstEmpty() == -1) { // 空のスロットがない
+            player.sendMessage("エラー：インベントリを空けてください！");
             return false;
         }
 
@@ -140,44 +140,43 @@ public class GachaCommand {
             return false;
         }
 
-        return issueTicket(player, playerSlot);
+        return issueTicket(player);
     }
 
     /**
      * チケット代を支払う
-     * @param econ
-     * @param player
+     * @param econ Economy instance
+     * @param player Player instance
      * @return boolean true: Success, false: Failure
      */
     private boolean payTicketPrice(Economy econ, Player player) {
-        sender.sendMessage(String.format("現在の現金 %s", econ.format(econ.getBalance(player))));
+        player.sendMessage(String.format("現在の現金 %s", econ.format(econ.getBalance(player))));
 
         if (!(econ.has(player, TICKET_PRICE))) {
-            sender.sendMessage(String.format("$%s持っていません！", TICKET_PRICE));
+            player.sendMessage(String.format("$%s持っていません！", TICKET_PRICE));
             return false;
         }
 
         EconomyResponse r = econ.withdrawPlayer(player, TICKET_PRICE);
 
         if (!(r.transactionSuccess())) {
-            sender.sendMessage(String.format("An error occurred: %s", r.errorMessage));
+            player.sendMessage(String.format("An error occurred: %s", r.errorMessage));
             return false;
         }
 
-        sender.sendMessage(String.format("お買い上げありがとうございます！$%s頂きました！", TICKET_PRICE));
+        player.sendMessage(String.format("お買い上げありがとうございます！$%s頂きました！", TICKET_PRICE));
         return true;
     }
 
     /**
      * チケットを発券する
-     * @param player
-     * @param playerSlot
+     * @param player Player instance
      * @return boolean
      */
-    private boolean issueTicket(Player player, int playerSlot) {
+    private boolean issueTicket(Player player) {
         String ticketCode = gacha.getDatabase().getTicket();
         if (ticketCode == null) {
-            GachaUtility.sendMessage(sender, "Failure generate ticket code.");
+            GachaUtility.sendMessage(player, "Failure generate ticket code.");
             return false;
         }
 
@@ -191,8 +190,8 @@ public class GachaCommand {
         lore.add(String.format(FORMAT_TICKET_CODE, ticketCode));
         im.setLore(lore);
         ticket.setItemMeta(im);
-        player.getInventory().setItem(playerSlot, ticket);
-        GachaUtility.sendMessage(sender, "Issue a ticket. player_name=" + sender.getName());
+        player.getInventory().setItem(player.getInventory().firstEmpty(), ticket);
+        GachaUtility.sendMessage(player, "Issue a ticket. player_name = " + player.getName());
         return true;
     }
 

--- a/src/main/java/space/gorogoro/gacha/GachaListener.java
+++ b/src/main/java/space/gorogoro/gacha/GachaListener.java
@@ -9,6 +9,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Chest;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.EntityType;
@@ -40,6 +41,44 @@ public class GachaListener implements Listener{
       this.gacha = gacha;
     } catch (Exception e){
       GachaUtility.logStackTrace(e);
+    }
+  }
+
+  /**
+   * チケット発行看板
+   * 看板の1行目に[ticket]の文字列がある看板が作成された際の処理
+   * @param event SignChangeEvent
+   */
+  @EventHandler(priority = EventPriority.HIGHEST)
+  public void onTicketSignBoard(SignChangeEvent event) {
+    if(!event.getLine(0).toLowerCase().equals("[ticket]")) {
+      return;
+    }
+
+    event.setLine(0, ChatColor.translateAlternateColorCodes(
+            '&', gacha.getConfig().getString("sign-line1-prefix") + event.getLine(0)));
+
+  }
+
+  /**
+   * プレイヤーが1行目に[ticket]の文字列がある看板を右クリックした際の処理
+   * @param event PlayerInteractEvent
+   */
+  @EventHandler(priority = EventPriority.HIGHEST)
+  public void onRightClick(PlayerInteractEvent event) {
+    if (!event.getAction().equals(Action.RIGHT_CLICK_BLOCK)) {
+      return;
+    }
+    Block clickedBlock = event.getClickedBlock();
+    Material material = clickedBlock.getType();
+    if (material.equals(Material.OAK_SIGN) || material.equals(Material.OAK_WALL_SIGN)) {
+      BlockState state = clickedBlock.getState();
+      Sign sign = (Sign) state;
+      // @TODO [ticket]が1行目にある看板限定だが、先頭にカラーコードがついているのでこのような暫定コード。もっとマシにリファクタリングすべき。
+      if (sign.getLine(0).equals("§6§l[ticket]")) {
+        GachaCommand command = gacha.getCommand();
+        command.ticket(Gacha.getEconomy(), event.getPlayer());
+      }
     }
   }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,10 +1,10 @@
 name: Gacha
-version: 1.0
+version: 1.1
 description: gacha.
 author: kubotan
 main: space.gorogoro.gacha.Gacha
-api-version: 1.14
-depend: [Vault]
+api-version: 1.15
+depend: [Vault, Essentials]
 
 commands:
   gacha:


### PR DESCRIPTION
コマンド入力を不要にするため下記の機能を実装しました。

1. オークの看板の1行目に `[ticket]` と記載し、それ以降の行は任意（書かなくても良い）
1. この看板を右クリックすることで$1000を支払いつつチケットを購入できるように
1. ついでに、従来からのコマンドも簡易化
  * 従来: `/gacha ticket @p`
  * 新版: `/gacha ticket`

コマンドの簡略化は、従来のコマンドでも動作するよう互換性は確保してありますので、そのまま
`@p`まで書いても問題ありません。